### PR TITLE
Add a symbolic link fetch method

### DIFF
--- a/core/deps.mk
+++ b/core/deps.mk
@@ -478,6 +478,10 @@ define dep_fetch_cp
 	cp -R $(call dep_repo,$(1)) $(DEPS_DIR)/$(call dep_name,$(1));
 endef
 
+define dep_fetch_ln
+	ln -sf $(call dep_repo,$(1)) $(DEPS_DIR)/$(call dep_name,$(1));
+endef
+
 define dep_fetch_hex.erl
 	ssl:start(),
 	inets:start(),

--- a/doc/src/guide/deps.asciidoc
+++ b/doc/src/guide/deps.asciidoc
@@ -167,6 +167,7 @@ The following table lists all existing methods:
 | hg             | hg repo commit  | Clone the Mercurial repository and update to the given version
 | svn            | svn repo        | Checkout the given SVN repository
 | cp             | cp path/to/repo | Recursively copy a local directory
+| ln             | ln path/to/repo | Create a symbolic link to a local directory
 | hex            | hex version     | Download the given project version from hex.pm
 | fail           | N/A             | Always fail, reserved for internal use
 | legacy         | N/A             | Legacy Erlang.mk fetcher, reserved for internal use


### PR DESCRIPTION
It is often useful not to copy dependencies but instead link to them. For example, share dependencies amongst projects.
This is supported by relx too (provided the link target exists at
runtime)
